### PR TITLE
Option to specify date format

### DIFF
--- a/R/jexcel.R
+++ b/R/jexcel.R
@@ -58,6 +58,9 @@
 #' \code{style = list("A1" = "background-color: gray;")}.
 #' @param autoColTypes a boolean value indicating if column type should be automatically detected if
 #' @param showToolbar a boolean value indicating if toolbar should be shown. By default it is set to false.
+#' @param dateFormat a  string value indicating the date format if column of type 'calendar' is present. By default the
+#' format is 'DD/MM/YYYY'. Valid date formats are 'DD/MM/YYYY', 'MM/DD/YYYY', 'YYYY/MM/DD', 'DD-MM-YYYY', 'MM-DD-YYYY'
+#' and 'YYYY-MM-DD'
 #' @import jsonlite
 #' @import htmlwidgets
 #' @example inst/examples/examples_widget.R
@@ -91,7 +94,8 @@ excelTable <-
            loadingSpin = FALSE,
            style = NULL,
            autoColTypes = TRUE,
-           showToolbar = FALSE) {
+           showToolbar = FALSE,
+           dateFormat = 'DD/MM/YYYY') {
     # List of parameters to send to js
     paramList <- list()
 
@@ -405,6 +409,18 @@ excelTable <-
       }
 
       paramList$style <- style
+    }
+
+    # Check date format
+    if(!is.null(dateFormat)){
+      validDateFormats <- c('DD/MM/YYYY', 'MM/DD/YYYY', 'YYYY/MM/DD', 'DD-MM-YYYY', 'MM-DD-YYYY', 'YYYY-MM-DD' )
+      if (!dateFormat %in% validDateFormats)  {
+        warning("Invalid dateFormat ", dateFormat, " specified, using 'DD/MM/YYYY' instead.")
+        paramList$dateFormat <- 'DD/MM/YYYY'
+      }else{
+        paramList$dateFormat <- dateFormat
+      }
+
     }
 
     # create the widget

--- a/inst/htmlwidgets/jexcel.js
+++ b/inst/htmlwidgets/jexcel.js
@@ -12,11 +12,25 @@
         renderValue: function(params) {
           var rowHeight = params.hasOwnProperty("rowHeight") ? params.rowHeight : undefined;
           var showToolbar = params.hasOwnProperty("showToolbar")? params.showToolbar: false;
+          var dateFormat = params.hasOwnProperty("dateFormat")? params.dateFormat: "DD/MM/YYYY";
           var otherParams = {};
           Object.keys(params).forEach(function(ky) {
-            if(params !== "rowHeight" && params !== "otherParams") {
-              otherParams[ky] = params[ky];
+        
+
+            if(ky !== "dateFormat" && ky !== "rowHeight" && ky !== "otherParams" ) {
+              // Check if the key is columns and check if the type is calendar, if yes add the date format
+              if(ky === "columns" && dateFormat !== "DD/MM/YYYY"){
+                otherParams[ky] = params[ky].map(function(column){
+                  if(column.type === "calendar"){
+                    column.options = {format: dateFormat}
+                  }
+                  return column
+                })
+              
+                return;
             }
+          }
+            otherParams[ky] = params[ky];
           });
     
           var rows = (function() {

--- a/man/excelTable.Rd
+++ b/man/excelTable.Rd
@@ -14,7 +14,7 @@ excelTable(data = NULL, columns = NULL, colHeaders = NULL,
   selectionCopy = TRUE, mergeCells = NULL, search = FALSE,
   pagination = NULL, fullscreen = FALSE, lazyLoading = FALSE,
   loadingSpin = FALSE, style = NULL, autoColTypes = TRUE,
-  showToolbar = FALSE)
+  showToolbar = FALSE, dateFormat = "DD/MM/YYYY")
 }
 \arguments{
 \item{data}{a data object, can either be dataframe or a matrix.}
@@ -102,6 +102,10 @@ a valid 'css' string with styles.  For example, to style cell 'A1', the list sho
 \item{autoColTypes}{a boolean value indicating if column type should be automatically detected if}
 
 \item{showToolbar}{a boolean value indicating if toolbar should be shown. By default it is set to false.}
+
+\item{dateFormat}{a  string value indicating the date format if column of type 'calendar' is present. By default the
+format is 'DD/MM/YYYY'. Valid date formats are 'DD/MM/YYYY', 'MM/DD/YYYY', 'YYYY/MM/DD', 'DD-MM-YYYY', 'MM-DD-YYYY'
+and 'YYYY-MM-DD'}
 }
 \description{
 This function is used to create excel like table

--- a/tests/testthat/test_dateFormat.R
+++ b/tests/testthat/test_dateFormat.R
@@ -1,0 +1,10 @@
+context("'dateFormat' argument")
+
+test_that("'dateFormat' argument gives warning for invalid format", {
+    testthat::expect_warning(excelTable(dateFormat= 'MM/DD/YYY'))
+})
+
+test_that("valid 'dateFormat' argument is passed to htmlwidget ", {
+  testthat::expect_type(excelTable(dateFormat = 'MM-DD-YYY')$x$dateFormat,  "character")
+})
+


### PR DESCRIPTION
This PR adds an additional parameter `dateFormat` which can be used to change the date format in `calendar` type.