### PR TITLE
Auto width height

### DIFF
--- a/R/jexcel.R
+++ b/R/jexcel.R
@@ -49,6 +49,10 @@
 #' @param dateFormat a  string value indicating the date format if column of type 'calendar' is present. By default the
 #' format is 'DD/MM/YYYY'.
 #' @param digits number of decimal digits passed to \code{jsonlite::toJSON}. By default it is set to 4, use \code{NA} for max precision.
+#' @param autoWidth a boolean value indicating should the width of the column be automatically adjusted. By default this value is set to TRUE.
+#' The width value specified in 'columns' param will have higher precedence.
+#' @param autoFill a boolen value indicating wheather the excel table fill the container. By default this value is set to false.
+#' The width value specified in 'columns' param will have highest precendence followed by autoWidth.
 #' @param  ... other jexcel parameters, e.g., updateTable
 #' @import jsonlite
 #' @import htmlwidgets
@@ -86,6 +90,8 @@ excelTable <-
            showToolbar = FALSE,
            dateFormat = 'DD/MM/YYYY',
            digits = 4,
+           autoWidth = TRUE,
+           autoFill = FALSE,
            ...
            ) {
     # List of parameters to send to js
@@ -330,7 +336,9 @@ excelTable <-
       "fullscreen",
       "lazyLoading",
       "loadingSpin",
-      "showToolbar"
+      "showToolbar",
+      "autoWidth",
+      "autoFill"
     )) {
       argvalue <- get(arg)
       if(!is.null(argvalue)) {

--- a/inst/htmlwidgets/jexcel.js
+++ b/inst/htmlwidgets/jexcel.js
@@ -13,11 +13,13 @@
           var rowHeight = params.hasOwnProperty("rowHeight") ? params.rowHeight : undefined;
           var showToolbar = params.hasOwnProperty("showToolbar")? params.showToolbar: false;
           var dateFormat = params.hasOwnProperty("dateFormat")? params.dateFormat: "DD/MM/YYYY";
-          var imageColIndex = undefined
+          var autoWidth = params.hasOwnProperty("autoWidth")? params.autoWidth: true;
+          var autoFill = params.hasOwnProperty("autoFill")? params.autoFill: false;
+          var imageColIndex = undefined;
           var otherParams = {};
 
           Object.keys(params).forEach(function(ky) {
-            if(ky !== "dateFormat" && ky !== "rowHeight" && ky !== "otherParams" ) {
+            if(ky !== "dateFormat" && ky !== "rowHeight" && ky !== "autoWidth" && ky !== "otherParams" ) {
               // Check if the key is columns and check if the type is calendar, if yes add the date format
               if(ky === "columns"){
                 otherParams[ky] = params[ky].map(function(column, index){
@@ -89,12 +91,22 @@
               { type:'color', content:'format_color_fill', k:'background-color' },
           ]
           }
-
+debugger;
           // If new instance of the table   
           if(excel === null) {
-            excel =  jexcel(container, otherParams,);
+            excel =  jexcel(container, otherParams);
+
+            if(autoWidth){
+              excel.table.setAttribute("style", "width: auto; height: auto; white-space: normal;")
+            }
+
+            if(!autoWidth && autoFill){
+              excel.table.setAttribute("style", "width: 100%; height: 100%; white-space: normal;")
+              container.getElementsByClassName("jexcel_content")[0].setAttribute("style", "height:100%")
+            }
+
             container.excel = excel;
-    
+
             return;
           }
 
@@ -108,6 +120,16 @@
           
           if(selection){
             excel.updateSelectionFromCoords(selection[0], selection[1], selection[2], selection[3]);
+          }
+
+
+          if(autoWidth){
+            excel.table.setAttribute("style", "width: auto; height: auto; white-space: normal;")
+          }
+
+          if(!autoWidth && autoFill){
+            excel.table.setAttribute("style", "width: 100%; height: 100%; white-space: normal;")
+            container.getElementsByClassName("jexcel_content")[0].setAttribute("style", "height:100%")
           }
 
           container.excel = excel;

--- a/man/excelTable.Rd
+++ b/man/excelTable.Rd
@@ -14,7 +14,8 @@ excelTable(data = NULL, columns = NULL, colHeaders = NULL,
   selectionCopy = TRUE, mergeCells = NULL, search = FALSE,
   pagination = NULL, fullscreen = FALSE, lazyLoading = FALSE,
   loadingSpin = FALSE, style = NULL, autoColTypes = TRUE,
-  showToolbar = FALSE, dateFormat = "DD/MM/YYYY", digits = 4, ...)
+  showToolbar = FALSE, dateFormat = "DD/MM/YYYY", digits = 4,
+  autoWidth = TRUE, autoFill = FALSE, ...)
 }
 \arguments{
 \item{data}{a data object, can either be dataframe or a matrix.}
@@ -95,6 +96,12 @@ a valid 'css' string with styles.  For example, to style cell 'A1', the list sho
 format is 'DD/MM/YYYY'.}
 
 \item{digits}{number of decimal digits passed to \code{jsonlite::toJSON}. By default it is set to 4, use \code{NA} for max precision.}
+
+\item{autoWidth}{a boolean value indicating should the width of the column be automatically adjusted. By default this value is set to TRUE.
+The width value specified in 'columns' param will have higher precedence.}
+
+\item{autoFill}{a boolen value indicating wheather the excel table fill the container. By default this value is set to false.
+The width value specified in 'columns' param will have highest precendence followed by autoWidth.}
 
 \item{...}{other jexcel parameters, e.g., updateTable}
 }

--- a/tests/testthat/test_creation.R
+++ b/tests/testthat/test_creation.R
@@ -27,7 +27,9 @@ test_that("logical arguments are logical and if not become NULL", {
         "search",
         "lazyLoading",
         "loadingSpin",
-        "showToolbar"
+        "showToolbar",
+        "autoWidth",
+        "autoFill"
   )) {
     l <- list()
     l[[arg]] <- 'not logical'
@@ -55,7 +57,8 @@ test_that("valid logical arguments are passed to htmlwidget", {
         "search",
         "lazyLoading",
         "loadingSpin",
-        "showToolbar"
+        "showToolbar",
+        "autoWidth"
   )) {
     l <- list()
     l[[arg]] <- TRUE


### PR DESCRIPTION
This PR addressed issue #27. To add auto fit and auto fit to container.

Two params have been added:
- `autoWidth`: Will adjust the column width of the table to fit the content 
- `autofill`: Will fill the container(in shiny mode) by adjusting the width and height. 