### PR TITLE
Fix single column data.frames having wrong column name 

### DIFF
--- a/inst/htmlwidgets/jexcel.js
+++ b/inst/htmlwidgets/jexcel.js
@@ -18,7 +18,6 @@
           var getSelectedData = params.hasOwnProperty("getSelectedData")? params.getSelectedData: false
           var imageColIndex = undefined;
           var otherParams = {};
-          
           Object.keys(params).forEach(function(ky) {
             if(ky !== "dateFormat" && 
             ky !== "rowHeight" && 
@@ -54,10 +53,19 @@
                 
                 return;
               }
+
+               // A vector containg single string is converted to string by jsonlite need to convert 
+               // it back to array of string for jexcel support
+              if(ky === "colHeaders" && typeof(params[ky]) === "string"){
+                otherParams[ky] = [params[ky]];
+                return;
+              }
             }
             otherParams[ky] = params[ky];
           });
-          
+
+         
+
           var rows = (function() {
             if (rowHeight) {
               var rows = {};

--- a/inst/htmlwidgets/jexcel.js
+++ b/inst/htmlwidgets/jexcel.js
@@ -18,6 +18,7 @@
           var getSelectedData = params.hasOwnProperty("getSelectedData")? params.getSelectedData: false
           var imageColIndex = undefined;
           var otherParams = {};
+
           Object.keys(params).forEach(function(ky) {
             if(ky !== "dateFormat" && 
             ky !== "rowHeight" && 
@@ -63,8 +64,6 @@
             }
             otherParams[ky] = params[ky];
           });
-
-         
 
           var rows = (function() {
             if (rowHeight) {


### PR DESCRIPTION
This PR fixes issue #80.
`Jsonlite` package was converting string vector into a single string instead of an array need for `colHeaders`.